### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Anıl ARAS
 maintainer=
 sentence=gps noktaları arasındaki açıyı verir.
 paragraph= Belirlenen iki gps noktası arasındaki açıyı verir.
-category=GPS
+category=Other
 url=http://www.anilaras.com.tr
 architectures=avr


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'GPS' in library gpsPointer is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format